### PR TITLE
HMAC sign hidden from URL requests and fix parsing URL Path

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,6 @@ function getToken(requestUrl, timestamp) {
 }
 
 function signUrl() {
-    // Make sure that URL does not contain hmac_timestamp and hmac_sign
-    pm.request.url.query.remove("hmac_timestamp");
-    pm.request.url.query.remove("hmac_sign");
-
     var timestamp = getTimestamp();
     var hmacSign = getToken(pm.request.url.getRaw(), timestamp);
     

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Recombee SHA1-HMAC Postman Pre-request Script 
-A simple Pre-request Script for Postman integration to make API requests against the Recombee(recombee.com) AI Recommender Engine. 
-It uses the SHA1-HMAC signing method and hashes the timestamp and some path variables into a SHA1 Token. 
+A simple Pre-request Script for Postman integration to make API requests against the [Recombee AI](recombee.com) Recommender Engine. 
+
+It uses the SHA1-HMAC signing method and hashes the timestamp and some path variables into a SHA1 Token.
+
 Follow the instructions in the script and your good to go. :)
 
 ```javascript
@@ -8,18 +10,22 @@ Follow the instructions in the script and your good to go. :)
 ==================
 1) Create an Environment (if you don't already have on) and enable it for your request
 2) Add two variables to your environment:
-    "RecombeeDB" and fill in our DB Name from Recombee as Initial Value
-    "PrivateToken" and fill in our Private Token from Recombee as Initial Value
-3) Add those new params for your request: 
-    "hmac_timestamp" with the value "{{hmac_timestamp}}"
-    "hmac_sign" with the value "{{hmac_sign}}"  
-    These params should always be at the end of the request to get the script working properly.
-    "filter" with the value "{{filter}}"
-    "booster" with the value "{{booster}}"
+    * "RecombeeDB" and fill in our DB Name from Recombee as Initial Value
+    * "PrivateToken" and fill in our Private Token from Recombee as Initial Value
+    * "BaseUrl" and fill in API endpoint (e.g. https://rapi.recombee.com)
+3) Add params for your request:
+    * "filter" with the value "{{filter}}"
+    * "booster" with the value "{{booster}}"
 4) Add the following Pre-request Script that computes the two variables and adds them into your environment
-5) Fill your and SECRET_KEY with your private key from Recombee(from the corresponding Recombee DB)
-6) Your request GET URL should look like this(Example to list all items from Recombee):
-    https://rapi.recombee.com/{{RecombeeDB}}/items/list/?hmac_timestamp={{hmac_timestamp}}&hmac_sign={{hmac_sign}}
+5) Your request GET URL should look like this (Example to list all items from Recombee):
+    `{{BaseUrl}}/{{RecombeeDB}}/items/list/`
+
+Example URLs:
+* Recommend items to item:
+    `{{BaseUrl}}/{{RecombeeDB}}/recomms/items/{{ITEM_ID}}/items/`
+* Recommend items to item with filter and booster:
+    `{{BaseUrl}}/{{RecombeeDB}}/recomms/items/{{ITEM_ID}}/items/?filter={{filter}}&booster={{booster}}`
+
 */
 
 //If you want to use the filter or boosting attributes, you need to set them here because of escaping logics of recombee and Postman. 
@@ -38,12 +44,13 @@ function getParams(params) {
 }
 
 function getPath(url) {
-    var pathRegex = /.+?\:\/\/.+?(\/.+?)(?:#|\&hmac|\?hmac|$)/;
-    var result = url.match(pathRegex);
-    return pm.variables.replaceIn(result) && result.length > 1 ? result[1] : ''; 
+    var url_replaced = pm.variables.replaceIn(url)
+    var pathRegex = /.+?\:\/\/.+?(\/.+?)(?:#|$)/;
+    var result = url_replaced.match(pathRegex);
+    return result.length > 1 ? result[1] : ''; 
 }
  
-function getToken(requestUrl) {
+function getToken(requestUrl, timestamp) {
     var SECRET_KEY = pm.environment.get("PrivateToken");
 
     var requestPath = getPath(requestUrl);
@@ -57,10 +64,24 @@ function getToken(requestUrl) {
         var separator = "?";
     }
     
-    var PathWithTimestamp = requestPath + separator + "hmac_timestamp=" + getTimestamp();
+    var PathWithTimestamp = requestPath + separator + "hmac_timestamp=" + timestamp;
     var SignedPath = CryptoJS.HmacSHA1(PathWithTimestamp, SECRET_KEY)
 
     return SignedPath;
+}
+
+function signUrl() {
+    // Make sure that URL does not contain hmac_timestamp and hmac_sign
+    pm.request.url.query.remove("hmac_timestamp");
+    pm.request.url.query.remove("hmac_sign");
+
+    var timestamp = getTimestamp();
+    var hmacSign = getToken(pm.request.url.getRaw(), timestamp);
+    
+    postman.setEnvironmentVariable('hmac_timestamp', timestamp);
+    postman.setEnvironmentVariable('hmac_sign', hmacSign);
+    pm.request.url.query.add("hmac_timestamp={{hmac_timestamp}}")
+    pm.request.url.query.add("hmac_sign={{hmac_sign}}")
 }
 
 function getTimestamp() {
@@ -77,6 +98,5 @@ if(filter == null || filter == "") {
 
 postman.setEnvironmentVariable("filter", getParams(filter));
 postman.setEnvironmentVariable("booster", getParams(booster));
-postman.setEnvironmentVariable('hmac_timestamp', getTimestamp());
-postman.setEnvironmentVariable('hmac_sign', getToken(pm.request.url.getRaw()));
+signUrl();
 ```


### PR DESCRIPTION
Hi Pascal,

I propose possibility to completely hide HMAC from request URLs when building recomm requests. There is also a benefit to it that `hmac_timestamp` and `hmac_sign` will be always last params.

This PR also include a fix for parsing URL path in `getPath` function. I had a problem when URL contained variables (e.g. `{{RecombeeDB}}` it would not parse correctly. So replacing variables before regex solved it.

```
var url_replaced = pm.variables.replaceIn(url)
```