### PR TITLE
Use Url#toString instead of discontinued Url#getRaw method

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ function getToken(requestUrl, timestamp) {
 
 function signUrl() {
     var timestamp = getTimestamp();
-    var hmacSign = getToken(pm.request.url.getRaw(), timestamp);
+    var hmacSign = getToken(pm.request.url.toString(), timestamp);
     
     postman.setEnvironmentVariable('hmac_timestamp', timestamp);
     postman.setEnvironmentVariable('hmac_sign', hmacSign);


### PR DESCRIPTION
 Url#getRaw has been discontinued in Postman 4.0.0 (https://github.com/postmanlabs/postman-collection/blob/develop/CHANGELOG.yaml#L32).